### PR TITLE
Update README and skill files for plugin architecture terminology

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Local development testing via `claude --plugin-dir`
 - Self-update support via plugin marketplace versioning
 
+### Fixed
+- Updated remaining "command" terminology to "skill" in plugin SKILL.md files (code-review, handoff)
+- Added v2.x deprecation note to YouTube demo video in README
+
 ### Removed
 - `install.sh` remote installer script (replaced by `/plugin marketplace add`)
 - `setup.sh` interactive setup script (replaced by plugin install + scaffold skill)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Updated remaining "command" terminology to "skill" in plugin SKILL.md files (code-review, handoff)
-- Added v2.x deprecation note to YouTube demo video in README
+- Removed outdated YouTube demo video (showed v2.x installation flow) from README
 
 ### Removed
 - `install.sh` remote installer script (replaced by `/plugin marketplace add`)

--- a/README.md
+++ b/README.md
@@ -81,9 +81,6 @@ No feedback when tasks complete
 > **Claude Code transforms from a helpful tool into a reliable development partner that remembers your project context, validates its own work, and handles the tedious stuff automatically.**
 
 
-[![Demo-Video auf YouTube](https://img.youtube.com/vi/kChalBbMs4g/0.jpg)](https://youtu.be/kChalBbMs4g)
-
-> *Note: This demo shows the v2.x installation flow. See the Quick Start section below for current plugin-based installation.*
 
 ## Quick Start
 

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ No feedback when tasks complete
 
 [![Demo-Video auf YouTube](https://img.youtube.com/vi/kChalBbMs4g/0.jpg)](https://youtu.be/kChalBbMs4g)
 
-
+> *Note: This demo shows the v2.x installation flow. See the Quick Start section below for current plugin-based installation.*
 
 ## Quick Start
 

--- a/plugins/cdk-core/skills/code-review/SKILL.md
+++ b/plugins/cdk-core/skills/code-review/SKILL.md
@@ -9,7 +9,7 @@ description: Multi-agent code review surfacing only critical, high-impact findin
 
 ## Core Philosophy
 
-This command prioritizes **needle-moving discoveries** over exhaustive lists. Every finding must demonstrate significant impact on:
+This skill prioritizes **needle-moving discoveries** over exhaustive lists. Every finding must demonstrate significant impact on:
 - System reliability & stability
 - Security vulnerabilities with real exploitation risk
 - Performance bottlenecks affecting user experience
@@ -26,7 +26,7 @@ Changes that unlock new capabilities, remove significant constraints, or improve
 Minor style issues, micro-optimizations (<10%), theoretical best practices, edge cases affecting <1% of users.
 
 
-## Command Execution
+## Skill Execution
 
 User provided context: "$ARGUMENTS"
 

--- a/plugins/cdk-core/skills/handoff/SKILL.md
+++ b/plugins/cdk-core/skills/handoff/SKILL.md
@@ -3,7 +3,7 @@ name: handoff
 description: Preserve context between sessions with intelligent handoff document management
 ---
 
-You are concluding work on the current project and need to create a comprehensive handoff for the next AI session. This command intelligently analyzes your current session achievements and updates the handoff document with both auto-detected progress and user-provided context.
+You are concluding work on the current project and need to create a comprehensive handoff for the next AI session. This skill intelligently analyzes your current session achievements and updates the handoff document with both auto-detected progress and user-provided context.
 
 ## Auto-Loaded Project Context:
 @docs/ai-context/HANDOFF.md


### PR DESCRIPTION
- Add v2.x deprecation note to YouTube demo video in README
- Update "command" → "skill" terminology in code-review and handoff SKILL.md files
- Add changelog entries for these fixes

Closes #16

https://claude.ai/code/session_01ArhbMrPmvMjJrKxH3CebmK